### PR TITLE
feat(auth): validate that the password must be different than username

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,7 +48,9 @@
     "usuario",
     "venv",
     "hibp",
-    "haveibeenpwned"
+    "haveibeenpwned",
+    "sslmode",
+    "txtgen"
   ],
   "dictionaries": [
     "en_US",

--- a/.pactum/snapshots/register-errors.json
+++ b/.pactum/snapshots/register-errors.json
@@ -6,6 +6,7 @@
     "email should not be empty",
     "email must be a string",
     "password should not be null or undefined",
+    "password must be different than username",
     "password must be shorter than or equal to 30 characters",
     "password must be longer than or equal to 8 characters",
     "password should not be empty",

--- a/src/auth/dto/__snapshots__/register-user.dto.spec.ts.snap
+++ b/src/auth/dto/__snapshots__/register-user.dto.spec.ts.snap
@@ -19,6 +19,7 @@ Array [
     "constraints": Object {
       "isDefined": "password should not be null or undefined",
       "isNotEmpty": "password should not be empty",
+      "isNotTheSame": "password must be different than username",
       "isString": "password must be a string",
       "maxLength": "password must be shorter than or equal to 30 characters",
       "minLength": "password must be longer than or equal to 8 characters",

--- a/src/auth/dto/register-user.dto.ts
+++ b/src/auth/dto/register-user.dto.ts
@@ -10,6 +10,7 @@ import {
 
 import { NormalizeEmail } from '@/auth/decorators/normalize-email.decorator';
 import { IsAlreadyRegister } from '@/auth/validators/is-already-register.validator';
+import { IsNotTheSame } from '@/auth/validators/is-not-the-same';
 import { IsNotVulnerable } from '@/auth/validators/is-not-vulnerable.validator';
 import { Trim } from '@/common/decorators/trim.decorator';
 
@@ -28,6 +29,7 @@ export class RegisterUser {
   @IsNotEmpty()
   @MinLength(8)
   @MaxLength(30)
+  @IsNotTheSame<RegisterUser>('username')
   @IsNotVulnerable()
   readonly password!: string;
 

--- a/src/auth/validators/is-not-the-same.spec.ts
+++ b/src/auth/validators/is-not-the-same.spec.ts
@@ -1,0 +1,36 @@
+import { validateSync } from 'class-validator';
+
+import { IsNotTheSame } from '@/auth/validators/is-not-the-same';
+
+describe('IsNotTheSame', () => {
+  class DTO {
+    readonly username!: string;
+
+    @IsNotTheSame<DTO>('username')
+    readonly password: string;
+
+    constructor(username: string, password: string) {
+      this.username = username;
+      this.password = password;
+    }
+  }
+
+  it("should pass when property's values are different", () => {
+    const dto = new DTO('john_doe', 'Th€Pa$$w0rd!');
+
+    const errors = validateSync(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should fail when property's values are equals", () => {
+    const dto = new DTO('john_doe', 'john_doe');
+
+    const errors = validateSync(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toMatchObject({
+      isNotTheSame: 'password must be different than username',
+    });
+  });
+});

--- a/src/auth/validators/is-not-the-same.ts
+++ b/src/auth/validators/is-not-the-same.ts
@@ -1,0 +1,39 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isNotTheSame' })
+export class IsNotTheSameConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, validationArguments: ValidationArguments): boolean {
+    const [property] = validationArguments.constraints as [string];
+    const object = validationArguments.object as Record<string, unknown>;
+
+    // eslint-disable-next-line security/detect-object-injection
+    return !Object.is(object[property], value);
+  }
+
+  defaultMessage({ constraints }: ValidationArguments) {
+    const [property] = constraints as [string];
+
+    return `$property must be different than ${property}`;
+  }
+}
+
+export function IsNotTheSame<Type>(
+  property: keyof Type,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [property],
+      validator: IsNotTheSameConstraint,
+    });
+  };
+}


### PR DESCRIPTION
When register an user, avoid that their password is equal than their username.

Reason: increase security